### PR TITLE
Null values instead of empty strings for admin_password

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ locals {
     linux_virtual_machine = {
       name                            = ""
       computer_name                   = ""
-      admin_password                  = ""
+      admin_password                  = null
       license_type                    = null
       allow_extension_operations      = false
       availability_set_id             = null


### PR DESCRIPTION
In newer Terraform versions, there is a difference whether you use an empty string or a null value for optional attributes. An empty string produces an error compared to a null value. To avoid such errors, the default value of admin_password has been changed to null.